### PR TITLE
add honeypot

### DIFF
--- a/src/pages/api/send-email.js
+++ b/src/pages/api/send-email.js
@@ -67,9 +67,9 @@ export async function POST({ request }) {
 
     const data = await mg.messages.create("mg.munch-industries.com", messageData);
 
-    return new Response(JSON.stringify({ success: true, message: "Email sent", data }), {
-      status: 200,
-    });
+    return new Response(
+      JSON.stringify({ success: true, message: "Form received" })
+    );
   } catch (error) {
     console.error("Mailgun error:", error);
     return new Response(

--- a/src/pages/api/send-email.js
+++ b/src/pages/api/send-email.js
@@ -37,11 +37,11 @@ export async function POST({ request }) {
     const { to, subject, text, html, "h:Reply-To": replyTo, website } = validationResult.data;
 
     // Honeypot check
-    if (website && website.trim() !== "") {
+    if (website) {
       console.log("Honeypot triggered at API level - possible bot submission");
       // Return success to not alert the bot
       return new Response(
-        JSON.stringify({ success: true, message: "Email sent" }),
+        JSON.stringify({ success: true, message: "Form received" }),
         { status: 200 }
       );
     }
@@ -68,7 +68,7 @@ export async function POST({ request }) {
     const data = await mg.messages.create("mg.munch-industries.com", messageData);
 
     return new Response(
-      JSON.stringify({ success: true, message: "Form received" })
+      JSON.stringify({ success: true, message: "Email sent" })
     );
   } catch (error) {
     console.error("Mailgun error:", error);

--- a/src/pages/api/send-email.js
+++ b/src/pages/api/send-email.js
@@ -11,8 +11,8 @@ const emailSchema = z.object({
   text: z.string().min(1, "Message must be nonempty"),
   html: z.string().optional(),
   "h:Reply-To": z.string().trim().email("Reply-To must be a valid email"),
+  website: z.string().optional(),
 });
-
 
 export async function POST({ request }) {
   try {
@@ -20,7 +20,7 @@ export async function POST({ request }) {
 
     // Validate the request body using Zod
     const validationResult = emailSchema.safeParse(emailData);
-    console.log(emailData)
+    console.log(emailData);
 
     if (!validationResult.success) {
       const errors = validationResult.error.flatten().fieldErrors;
@@ -34,7 +34,17 @@ export async function POST({ request }) {
       );
     }
 
-    const { to, subject, text, html, "h:Reply-To": replyTo } = validationResult.data;
+    const { to, subject, text, html, "h:Reply-To": replyTo, website } = validationResult.data;
+
+    // Honeypot check
+    if (website && website.trim() !== "") {
+      console.log("Honeypot triggered at API level - possible bot submission");
+      // Return success to not alert the bot
+      return new Response(
+        JSON.stringify({ success: true, message: "Email sent" }),
+        { status: 200 }
+      );
+    }
 
     if (!process.env.MAILGUN_API_KEY) {
       throw new Error("Missing Mailgun API key");

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -127,6 +127,14 @@ if (Astro.request.method === "POST") {
     font-size: 15px;
     font-weight: 600;
   }
+
+  /* Hide honeypot field from users */
+  .honeypot-field {
+    position: absolute;
+    left: -5000px;
+    opacity: 0;
+    pointer-events: none;
+  }
 </style>
 <Layout metadata={metadata}>
   <div
@@ -157,6 +165,18 @@ if (Astro.request.method === "POST") {
     <div id="form" class="flex justify-center mt-[71px]">
       <div class="bg-white rounded-md w-[80%] lg:w-[48%] contact-form p-10">
         <form method="POST">
+          <!-- Honeypot field - hidden from users but visible to bots -->
+          <div class="honeypot-field">
+            <label for="website">Website</label>
+            <input 
+              type="text" 
+              name="website" 
+              id="website"
+              tabindex="-1"
+              autocomplete="off"
+            />
+          </div>
+
           <div id="textinputs">
             <div class="flex mb-[45px]">
               <div>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -5,6 +5,8 @@ import dots from "~/assets/images/bg-design/contact-header-bg.png";
 import contactTitle from "~/assets/images/contact-title.png";
 import DOMPurify from 'dompurify';
 import { JSDOM } from 'jsdom';
+import "~/styles/contact.css";
+import { preventSpam } from '~/utils/preventSpam'; 
 
 const metadata = {
   title: "Contact",
@@ -77,65 +79,6 @@ if (Astro.request.method === "POST") {
   }
 }
 ---
-
-<style>
-
-  .contact-subtitle {
-  text-align: center;
-  font-size: 24px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 30px; /* 125% */
-  letter-spacing: 1.92px;
-  }
-
-  .contact-label {
-    color: #1A2634;
-    font-size: 15px;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 20px;
-    font-family: Lato;
-  }
-
-  @media (min-width: 1024px) {
-    .bg-contact-form{
-      background-image: url("../assets/images/bg-design/contact-form-bg.png");
-      background-repeat: no-repeat;
-      background-size: 100% 100%;
-    }
-  }
-  
-
-  .contact-form {
-    border-radius: 10px;
-    background: white;
-    box-shadow: 6px 6px 5px 3px rgba(0, 0, 0, 0.3);
-  }
-
-  .contact-input {
-    color: black;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 20px; /* 142.857% */
-    font-family: var(--aw-font-serif), ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
-  }
-
-  .contact-label {
-    font-family: var(--aw-font-serif), ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
-    font-size: 15px;
-    font-weight: 600;
-  }
-
-  /* Hide honeypot field from users */
-  .honeypot-field {
-    position: absolute;
-    left: -5000px;
-    opacity: 0;
-    pointer-events: none;
-  }
-</style>
 <Layout metadata={metadata}>
   <div
     id="header"
@@ -166,7 +109,7 @@ if (Astro.request.method === "POST") {
       <div class="bg-white rounded-md w-[80%] lg:w-[48%] contact-form p-10">
         <form method="POST">
           <!-- Honeypot field - hidden from users but visible to bots -->
-          <div class="honeypot-field">
+          <div class="website-field">
             <label for="website">Website</label>
             <input 
               type="text" 
@@ -280,122 +223,6 @@ if (Astro.request.method === "POST") {
       </div>
     </div>
 
-    <script>
-      /**
-       * Client-side form validation script
-       * Provides real-time feedback to users as they interact with the form
-       * while maintaining server-side validation for security
-       */
-      import DOMPurify from 'dompurify';
-
-      // Initialize form and input elements
-      const form = document.querySelector('form');
-      const inputs = {
-        firstName: form.querySelector('input[name="FirstName"]'),
-        lastName: form.querySelector('input[name="LastName"]'),
-        email: form.querySelector('input[name="Email"]'),
-        subject: form.querySelectorAll('input[name="Subject"]'),
-        message: form.querySelector('input[name="Message"]')
-      };
-
-      // Get corresponding error message elements for each input
-      const errorElements = {
-        firstName: form.querySelector('input[name="FirstName"] + p'),
-        lastName: form.querySelector('input[name="LastName"] + p'),
-        email: form.querySelector('input[name="Email"] + p'),
-        subject: document.querySelector('#subject-select p'),
-        message: form.querySelector('input[name="Message"] + p')
-      };
-
-      /**
-       * Validation rules for each form field
-       * Each function returns an empty string if valid, or an error message if invalid
-       * All inputs are sanitized before validation
-       */
-      const validators = {
-        firstName: (value) => {
-          const sanitized = DOMPurify.sanitize(value);
-          if (!sanitized || sanitized.length < 1) return "Please enter your first name.";
-          return "";
-        },
-        lastName: (value) => {
-          const sanitized = DOMPurify.sanitize(value);
-          if (!sanitized || sanitized.length < 1) return "Please enter your last name.";
-          return "";
-        },
-        email: (value) => {
-          const sanitized = DOMPurify.sanitize(value);
-          if (!sanitized || !sanitized.includes('@') || !sanitized.includes('.')) {
-            return "Please enter a valid email address.";
-          }
-          return "";
-        },
-        subject: (elements) => {
-          const selected = Array.from(elements).some(radio => radio.checked);
-          return selected ? "" : "Please select a subject.";
-        },
-        message: (value) => {
-          const sanitized = DOMPurify.sanitize(value);
-          if (!sanitized || sanitized.length < 1) return "Please enter your message.";
-          return "";
-        }
-      };
-
-      // Add form submit handler to sanitize all data before submission
-      form.addEventListener('submit', (e) => {
-        const formData = new FormData(form);
-        for (let [key, value] of formData.entries()) {
-          if (typeof value === 'string') {
-            formData.set(key, DOMPurify.sanitize(value));
-          }
-        }
-      });
-
-      /**
-       * Updates the error message display for a given field
-       * @param {string} field - The field name (firstName, lastName, etc.)
-       * @param {string} message - The error message (empty if valid)
-       */
-      function updateErrorMessage(field, message) {
-        const errorElement = errorElements[field];
-        if (errorElement) {
-          errorElement.textContent = message;
-          // Only show the error element if there's an error message
-          errorElement.style.display = message ? 'block' : 'none';
-        }
-      }
-
-      // Add real-time validation listeners to text inputs
-      inputs.firstName.addEventListener('input', (e) => {
-        updateErrorMessage('firstName', validators.firstName(e.target.value));
-      });
-
-      inputs.lastName.addEventListener('input', (e) => {
-        updateErrorMessage('lastName', validators.lastName(e.target.value));
-      });
-
-      inputs.email.addEventListener('input', (e) => {
-        updateErrorMessage('email', validators.email(e.target.value));
-      });
-
-      // Add change listeners to radio buttons
-      inputs.subject.forEach(radio => {
-        radio.addEventListener('change', () => {
-          updateErrorMessage('subject', validators.subject(inputs.subject));
-        });
-      });
-
-      inputs.message.addEventListener('input', (e) => {
-        updateErrorMessage('message', validators.message(e.target.value));
-      });
-
-      // Initialize error messages as hidden
-      Object.keys(errorElements).forEach(field => {
-        const errorElement = errorElements[field];
-        if (errorElement) {
-          errorElement.style.display = 'none';
-        }
-      });
-    </script>
+<script src="~/utils/contactForm.js"></script>
   </div>
 </Layout>

--- a/src/styles/contact.css
+++ b/src/styles/contact.css
@@ -1,0 +1,56 @@
+  .contact-subtitle {
+  text-align: center;
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 30px; /* 125% */
+  letter-spacing: 1.92px;
+  }
+
+  .contact-label {
+    color: #1A2634;
+    font-size: 15px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 20px;
+    font-family: Lato;
+  }
+
+  @media (min-width: 1024px) {
+    .bg-contact-form{
+      background-image: url("../assets/images/bg-design/contact-form-bg.png");
+      background-repeat: no-repeat;
+      background-size: 100% 100%;
+    }
+  }
+  
+
+  .contact-form {
+    border-radius: 10px;
+    background: white;
+    box-shadow: 6px 6px 5px 3px rgba(0, 0, 0, 0.3);
+  }
+
+  .contact-input {
+    color: black;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 20px; /* 142.857% */
+    font-family: var(--aw-font-serif), ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+  }
+
+  .contact-label {
+    font-family: var(--aw-font-serif), ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+    font-size: 15px;
+    font-weight: 600;
+  }
+
+  /* Hide honeypot field from users */
+  .website-field {
+    position: absolute;
+    left: -5000px;
+    opacity: 0;
+    display: None;
+    pointer-events: none;
+  }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -8,6 +8,11 @@ const getSite = () => ({
   googleSiteVerificationId: 'orcPxI47GSa-cRvY11tUe6iGg2IO_RPvnA1q95iEM3M',
 });
 
+const getSpam = () => ({
+  honeypotField: 'honeypot',
+  honeypotDuration: 2000,
+});
+
 const getMetadata = () => ({
   title: {
     default: DEFAULT_SITE_NAME,
@@ -148,6 +153,7 @@ export const METADATA = getMetadata();
 export const APP_BLOG = getAppBlog();
 export const UI = getUI();
 export const ANALYTICS = getAnalytics();
+export const SPAM = getSpam();  
 
 // const config = yaml.load(fs.readFileSync('src/config.yaml', 'utf8')) as {
 //   site?: SiteConfig;

--- a/src/utils/contactForm.js
+++ b/src/utils/contactForm.js
@@ -9,8 +9,6 @@ function initForm() {
   }
 
   preventSpam(form, { honeypotField: 'website' })
-  
-  console.log("Form after preventSpam:", form)
 
   form.addEventListener('submit', (e) => {
     if (form.containsSpam()) {

--- a/src/utils/contactForm.js
+++ b/src/utils/contactForm.js
@@ -1,0 +1,28 @@
+import { preventSpam } from '~/utils/preventSpam';
+
+function initForm() {
+  const form = document.querySelector('form');
+  
+  if (!form) {
+    console.error("Form not found!");
+    return;
+  }
+
+  preventSpam(form, { honeypotField: 'website' })
+  
+  console.log("Form after preventSpam:", form)
+
+  form.addEventListener('submit', (e) => {
+    if (form.containsSpam()) {
+      e.preventDefault();
+      return;
+    }
+
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initForm);
+} else {
+  initForm();
+}

--- a/src/utils/preventSpam.js
+++ b/src/utils/preventSpam.js
@@ -1,7 +1,9 @@
-export function preventSpam(
-  form,
-  { honeypotField = 'honeypot', honeypotDuration = 2000 } = {}
-) {
+import { SPAM } from '~/utils/config';
+
+export function preventSpam(form, overrides = {}) {
+  const config = { ...SPAM, ...overrides };
+  const { honeypotField, honeypotDuration } = config;
+
   const startTime = Date.now();
   let hasInteraction = false;
 

--- a/src/utils/preventSpam.js
+++ b/src/utils/preventSpam.js
@@ -1,0 +1,32 @@
+export function preventSpam(
+  form,
+  { honeypotField = 'honeypot', honeypotDuration = 10000 } = {}
+) {
+  const startTime = Date.now();
+  let hasInteraction = false;
+
+  // Check for user interaction
+  function checkForInteraction() {
+    hasInteraction = true;
+  }
+
+  // Listen for a couple of events to check interaction
+  const events = ['keydown', 'mousemove', 'touchstart', 'click'];
+  events.forEach(event => {
+    form.addEventListener(event, checkForInteraction, { once: true });
+  });
+
+  // Check for spam via all the available methods
+  form.containsSpam = function () {
+    const fillTime = Date.now() - startTime;
+    const isTooFast = fillTime < honeypotDuration;
+    const honeypotInput = form.querySelector(`[name="${honeypotField}"]`);
+    const hasHoneypotValue = honeypotInput?.value?.trim();
+    const noInteraction = !hasInteraction;
+
+    // Clean up event listeners after use
+    events.forEach(event => form.removeEventListener(event, checkForInteraction));
+
+    return isTooFast || !!hasHoneypotValue || noInteraction;
+  };
+}

--- a/src/utils/preventSpam.js
+++ b/src/utils/preventSpam.js
@@ -1,6 +1,6 @@
 export function preventSpam(
   form,
-  { honeypotField = 'honeypot', honeypotDuration = 10000 } = {}
+  { honeypotField = 'honeypot', honeypotDuration = 2000 } = {}
 ) {
   const startTime = Date.now();
   let hasInteraction = false;


### PR DESCRIPTION
I added a honeypot field to the contact form to catch spam bots (it's an invisible text input that bots typically fill out but people won't, which is supposed to generally catch a good amount of bots). 

tested by curling requests to the website such as:

```
# Test with honeypot
curl -X POST http://localhost:4321/api/send-email \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Test User",
    "email": "test@example.com",
    "message": "This is a test message with honeypot filled",
    "website": "http://spam.com"
  }'

# Test without honeypot
curl -X POST http://localhost:4321/api/send-email \
  -H "Content-Type: application/json" \
  -d '{
    "name": "Test User",
    "email": "test@example.com",
    "message": "This is a legitimate test message"
  }'
```

both tests should return a success message so that the bot doesn't know that the email failed, but only the curl without the honeypot filled should actually send the email. 