### PR TITLE
pass honeypot field to backend

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -35,49 +35,55 @@ if (Astro.request.method === "POST") {
     const email = purify.sanitize(String(data.get("Email") || ""));
     const subject = purify.sanitize(String(data.get("Subject") || ""));
     const message = purify.sanitize(String(data.get("Message") || ""));
+    const website = purify.sanitize(String(data.get("website") || ""));
 
-    // Validate form data
-    if (firstName.length < 1) {
-      errors.firstName = "Please enter your first name.";
-    }
-    if (lastName.length < 1) {
-      errors.lastName = "Please enter your last name.";
-    }
-    if (!email.includes("@") || !email.includes(".")) {
-      errors.email = "Please enter a valid email address.";
-    }
-    if (!subject) {
-      errors.subject = "Please select a subject.";
-    }
-    if (message.length < 1) {
-      errors.message = "Please enter your message.";
-    }
-
-    const hasErrors = Object.values(errors).some((msg) => msg);
-
-    if (!hasErrors) {
-      const content = `First Name: ${firstName}\nLast Name: ${lastName}\nPhone Number: ${phoneNumber}\nEmail: ${email}\n\nSubject: ${subject}\n\nMessage: ${message}`;
-
-      const emailData = {
-        to: "info@orble-tea.com",
-        subject: "Customer Inquiry Form Submission: " + subject,
-        text: content,
-        "h:Reply-To": email,
-      };
-
-      const response = await fetch(`${Astro.url.origin}/api/send-email`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(emailData),
-      });
-
-      if (!response.ok) {
-        throw new Error("An error occurred while sending the email.");
+    if (website) {
+      log = "Form submitted successfully!"; // Fake success for bots
+    } else {
+      // Validate form data
+      if (firstName.length < 1) {
+        errors.firstName = "Please enter your first name.";
+      }
+      if (lastName.length < 1) {
+        errors.lastName = "Please enter your last name.";
+      }
+      if (!email.includes("@") || !email.includes(".")) {
+        errors.email = "Please enter a valid email address.";
+      }
+      if (!subject) {
+        errors.subject = "Please select a subject.";
+      }
+      if (message.length < 1) {
+        errors.message = "Please enter your message.";
       }
 
-      log = "Form submitted successfully!";
+      const hasErrors = Object.values(errors).some((msg) => msg);
+
+      if (!hasErrors) {
+        const content = `First Name: ${firstName}\nLast Name: ${lastName}\nPhone Number: ${phoneNumber}\nEmail: ${email}\n\nSubject: ${subject}\n\nMessage: ${message}`;
+
+        const emailData = {
+          to: "info@orble-tea.com",
+          subject: "Customer Inquiry Form Submission: " + subject,
+          text: content,
+          "h:Reply-To": email,
+          website: website
+        };
+
+        const response = await fetch(`${Astro.url.origin}/api/send-email`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(emailData),
+        });
+
+        if (!response.ok) {
+          throw new Error("An error occurred while sending the email.");
+        }
+
+        log = "Form submitted successfully!";
+      }
     }
   } catch (error) {
     console.error(error);

--- a/src/styles/contact.css
+++ b/src/styles/contact.css
@@ -51,6 +51,6 @@
     position: absolute;
     left: -5000px;
     opacity: 0;
-    display: None;
+    display: none;
     pointer-events: none;
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -35,7 +35,7 @@ const getSpam = (): {
   honeypotField: string;
   honeypotDuration: number;
 } => ({
-  honeypotField: "honeypot",
+  honeypotField: "website",
   honeypotDuration: 2000,
 });
 


### PR DESCRIPTION
# Munch Pull Request Review Template

## Summary

- This PR adds the honeypot field as a parameter in the form data that gets passed to the backend. Previously, it was not getting passed from the frontend, which may be why some spam was getting through if spam bots were submitting through the form. If they were hitting the backend directly, then this fix will not help, and maybe the issue is the way the honeypot is hidden. For now I'll just make this fix, since I think adding logging/visibility into spam metrics will also help debug what the issue is, and why only much-website is letting spam through and not orble-site. (will work on adding metrics next, whcih will hopefully show how the bots are submitting, and whether the same number of bots are hitting both sites)

---

## Mini Runbook

- to run, clone this branch and run npm install, then npm run dev

---

## Testing
- tested by submitting directly through the form and through curl requests directly to the backend both with/without the honeypot filled in. 

## Checklist

- [x] I have run a linter, commented my code, and removed unused statements
- [ ] I have updated the documentation on Confluence. (no need)
- [x] My build succeeds locally and remotely. If not, explain why.

